### PR TITLE
解决滚动表格时切换渲染容器排序data-index出现计算错误的问题

### DIFF
--- a/src/vue-element-bigdata-table/mixins/data-handle.js
+++ b/src/vue-element-bigdata-table/mixins/data-handle.js
@@ -36,7 +36,7 @@ export default {
       /**
       * @description 表格行高
       */
-      itemRowHeight: 30,
+      itemRowHeight: 48,
       //  表格滚动区域高度
       wrapperHeight: 0,
       // 当前展示的表格是第几个


### PR DESCRIPTION
修改itemRowHeight中默认表格行高为element表格默认行高48 #1 