### PR TITLE
fix scrollY theader and tbody does not match

### DIFF
--- a/src/vue-element-bigdata-table/table-layout.js
+++ b/src/vue-element-bigdata-table/table-layout.js
@@ -157,8 +157,8 @@ class TableLayout {
           column.realWidth = column.minWidth;
         });
       }
-
-      this.bodyWidth = Math.max(bodyMinWidth, bodyWidth);
+      // fix scrollY theader and tbody does not match
+      this.bodyWidth = Math.max(bodyMinWidth, bodyWidth - scrollYWidth);
     } else {
       flattenColumns.forEach((column) => {
         if (!column.width && !column.minWidth) {


### PR DESCRIPTION
当有纵向滚动条的时候,表头和表格错位
根据代码,我发现是这里的宽度计算忘记减掉滚动条的宽度了,所以这里补上
PS:十分感谢你的这个组件,解决了我不少问题