### PR TITLE
有固定列时可响应hover

### DIFF
--- a/src/vue-element-bigdata-table/table-body.js
+++ b/src/vue-element-bigdata-table/table-body.js
@@ -141,11 +141,15 @@ export default {
 
   watch: {
     'store.states.hoverRow' (newVal, oldVal) {
-      if (!this.store.states.isComplex) return;
+//       if (!this.store.states.isComplex) return;
       const el = this.$el;
       if (!el) return;
       const tr = el.querySelector('tbody').children;
       const rows = [].filter.call(tr, row => hasClass(row, 'el-table__row'));
+      if (this.itemNum) {
+        newVal %= this.itemNum;
+        oldVal %= this.itemNum;
+      }
       const oldRow = rows[oldVal];
       const newRow = rows[newVal];
       if (oldRow) {


### PR DESCRIPTION
当表格有固定列时,初始表格响应hover,后续表格则不响应,
这里看了一下,应该是hoverRow保存的是index,而这个index是对应全局的index,改造后的表格是又三个表格拼接起来的,所以按照这个index是找不到对应的tr的,这里做了一下处理,让 index 对 itemNum 取模,这样就可以得到当前的tr了,测试可以正常响应hover