### PR TITLE
解决筛选报错问题

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -49,7 +49,11 @@ module.exports = {
         loader: 'babel-loader',
         include: [
           path.resolve(__dirname, 'src'),
-          path.resolve(__dirname, 'node_modules/element-ui/src')
+//           path.resolve(__dirname, 'node_modules/element-ui/src')
+          path.resolve(__dirname, 'node_modules/_element-ui@2.8.2@element-ui/src')
+        ],
+        exclude: [
+          path.resolve(__dirname, 'node_modules/_element-ui@2.8.2@element-ui/src/utils/popper.js')
         ]
       },
       {


### PR DESCRIPTION
排除popper.js的编译，否则筛选的时候会出现以下错误：

TypeError: o is not a constructor
at je.createPopper (vue-elementui-bigdata-table.js?f9b4:formatted:10155)
at je.updatePopper (vue-elementui-bigdata-table.js?f9b4:formatted:10169)
at je.showPopper (vue-elementui-bigdata-table.js?f9b4:formatted:10136)
at xa.run (vue-elementui-bigdata-table.js?f9b4:formatted:3648)
at Wt (vue-elementui-bigdata-table.js?f9b4:formatted:867)
at Array.eval (vue-elementui-bigdata-table.js?f9b4:formatted:515)
at at (vue-elementui-bigdata-table.js?f9b4:formatted:500)